### PR TITLE
Fixes for 5.4 and VR

### DIFF
--- a/Assets/Shaders/TemporalReprojection.shader
+++ b/Assets/Shaders/TemporalReprojection.shader
@@ -28,7 +28,6 @@ Shader "Playdead/Post/TemporalReprojection"
 
 	static const float FLT_EPS = 0.00000001f;
 
-	uniform float4x4 _CameraToWorld;
 	uniform sampler2D _CameraDepthTexture;
 	uniform float4 _CameraDepthTexture_TexelSize;
 
@@ -56,8 +55,11 @@ Shader "Playdead/Post/TemporalReprojection"
 	v2f vert(appdata_img IN)
 	{
 		v2f OUT;
-
-		OUT.cs_pos = mul(UNITY_MATRIX_MVP, IN.vertex);
+		#if UNITY_VERSION >= 540 //Matrix handling was changed in 5.4 and a Unity method was implemented for dealing with difference and VR
+			OUT.cs_pos = UnityObjectToClipPos(IN.vertex);
+		#else
+			OUT.cs_pos = mul(UNITY_MATRIX_MVP, IN.vertex);
+		#endif
 		OUT.ss_txc = IN.texcoord.xy;
 		OUT.vs_ray = (2.0 * IN.texcoord.xy - 1.0) * _Corner.xy;
 		

--- a/Assets/Shaders/TemporalReprojection.shader
+++ b/Assets/Shaders/TemporalReprojection.shader
@@ -33,7 +33,9 @@ Shader "Playdead/Post/TemporalReprojection"
 
 	uniform sampler2D _MainTex;
 	uniform float4 _MainTex_TexelSize;
-
+	#if UNITY_VERSION >= 540
+	half4 _MainTex_ST;
+	#endif
 	uniform sampler2D _VelocityBuffer;
 	uniform sampler2D _VelocityNeighborMax;
 
@@ -57,11 +59,14 @@ Shader "Playdead/Post/TemporalReprojection"
 		v2f OUT;
 		#if UNITY_VERSION >= 540 //Matrix handling was changed in 5.4 and a Unity method was implemented for dealing with difference and VR
 			OUT.cs_pos = UnityObjectToClipPos(IN.vertex);
+			float2 UV = UnityStereoScreenSpaceUVAdjust(IN.texcoord.xy, _MainTex_ST);
+			OUT.ss_txc = UV;
+			OUT.vs_ray = (2.0 * UV - 1.0) * _Corner.xy;
 		#else
 			OUT.cs_pos = mul(UNITY_MATRIX_MVP, IN.vertex);
+			OUT.ss_txc = IN.texcoord.xy;
+			OUT.vs_ray = (2.0 * IN.texcoord.xy - 1.0) * _Corner.xy;
 		#endif
-		OUT.ss_txc = IN.texcoord.xy;
-		OUT.vs_ray = (2.0 * IN.texcoord.xy - 1.0) * _Corner.xy;
 		
 		return OUT;
 	}

--- a/Assets/Shaders/VelocityBuffer.shader
+++ b/Assets/Shaders/VelocityBuffer.shader
@@ -3,7 +3,6 @@
 // AUTHOR: Lasse Jon Fuglsang Pedersen <lasse@playdead.com>
 Shader "Playdead/Post/VelocityBuffer"
 {
-
 	CGINCLUDE
 	//--- program begin
 	#pragma multi_compile __ TILESIZE_10 TILESIZE_20 TILESIZE_40 UNITY_SHADER_NO_UPGRADE
@@ -40,12 +39,14 @@ Shader "Playdead/Post/VelocityBuffer"
 
 		#if UNITY_VERSION < 540 //Matrix handling was changed in 5.4 and a Unity method was implemented for dealing with difference and VR
 			OUT.cs_pos = mul(UNITY_MATRIX_MVP, IN.vertex);
+			OUT.ss_txc = IN.texcoord.xy;
+			OUT.vs_ray = (2.0 * IN.texcoord.xy - 1.0) * _Corner.xy + _Corner.zw;
 		#else
 			OUT.cs_pos = UnityObjectToClipPos(IN.vertex);
+			float2 UV = UnityStereoScreenSpaceUVAdjust(IN.texcoord.xy, _MainTex_ST);
+			OUT.ss_txc = UV;
+			OUT.vs_ray = (2.0 * UV - 1.0) * _Corner.xy + _Corner.zw;
 		#endif
-
-		OUT.ss_txc = IN.texcoord.xy;
-		OUT.vs_ray = (2.0 * IN.texcoord.xy - 1.0) * _Corner.xy + _Corner.zw;
 
 		return OUT;
 	}


### PR DESCRIPTION
Implemented the world matrix macro introduced in 5.4 for dealing with
the velocity buffer and VR properly. Put in Unity version checks to retain compatibility with <5.4 Unity versions.