### PR TITLE
Fix jittery output on iOS

### DIFF
--- a/Assets/Scripts/TemporalReprojection.cs
+++ b/Assets/Scripts/TemporalReprojection.cs
@@ -149,9 +149,9 @@ public class TemporalReprojection : EffectBase
             mrt[0] = reprojectionBuffer[eyeIndex, indexWrite].colorBuffer;
             mrt[1] = destination.colorBuffer;
 
+            reprojectionBuffer[eyeIndex, indexWrite].DiscardContents();
             Graphics.SetRenderTarget(mrt, source.depthBuffer);
             reprojectionMaterial.SetPass(0);
-            reprojectionBuffer[eyeIndex, indexWrite].DiscardContents();
 
             DrawFullscreenQuad();
 


### PR DESCRIPTION
#24
The blinking output is caused by an empty reprojectionBuffer.

## Before
![image](https://user-images.githubusercontent.com/7625588/113482799-027ef700-94ec-11eb-9ae2-ed3272307a9a.png)

## After
![image](https://user-images.githubusercontent.com/7625588/113482820-10347c80-94ec-11eb-9702-064c42ae746a.png)
